### PR TITLE
Add "NaN loses" comparisons

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -3956,18 +3956,28 @@ MASK_DESCRIPTIONS = {
 # TODO
 # uses sr60 implicitly?
 @register
-class BlendDesc(InstructionDesc):
+class LdstTileDesc(InstructionDesc):
 	def __init__(self):
-		super().__init__('blend', size=8)
+		super().__init__('ld/st_tile', size=8)
 
-		self.add_constant(0, 7, 0x09)
+		self.add_constant(0, 6, 0x09)
 
-		# XXX: actually a source! ALUDstDesc's cache hint possibly a discard hint.
+		# Direction of the transfer, set for tilebuffer->register,
+		# clear for register->tilebuffer
+		self.add_operand(ImmediateDesc('load', 6, 1))
+
+		# If load is false, actually a source! ALUDstDesc's cache hint possibly a discard hint.
 		self.add_operand(ALUDstDesc('D', 60))
 
 		self.add_operand(EnumDesc('F', 24, 4, MEMORY_FORMATS))
-		self.add_operand(ImmediateDesc('rt', 32, 4))
+		self.add_operand(ImmediateDesc('rt', 32, 3))
+		self.add_operand(ImmediateDesc('u0', 35, 1))
 		self.add_operand(EnumDesc('mask', 36, 4, MASK_DESCRIPTIONS))
+
+	def map_to_alias(self, mnem, operands):
+		is_load = operands[0]
+		mnem = 'ld_tile' if is_load else 'st_tile'
+		return mnem, operands[1:]
 
 @register
 class LoadVarDesc(InstructionDesc):

--- a/applegpu.py
+++ b/applegpu.py
@@ -3982,7 +3982,7 @@ class LdstTileDesc(InstructionDesc):
 @register
 class LoadVarDesc(InstructionDesc):
         def __init__(self):
-                super().__init__('ld_var', size=8)
+                super().__init__('ld_var', size=(4, 8))
 
                 self.add_constant(0, 6, 0x21)
                 self.add_operand(ALUDstDesc('D', 60)) # TODO: confirm extension

--- a/applegpu.py
+++ b/applegpu.py
@@ -1570,10 +1570,14 @@ class FConditionDesc(BaseConditionDesc):
 			return FloatLessThanComparison(invert_result)
 		if condition == 0b010:
 			return FloatGreaterThanComparison(invert_result)
+		if condition == 0b011:
+			return FloatLessThanNanLosesComparison(invert_result)
 		if condition == 0b101:
 			return FloatLessThanOrEqualComparison(invert_result)
 		if condition == 0b110:
 			return FloatGreaterThanOrEqualComparison(invert_result)
+		if condition == 0b111:
+			return FloatGreaterThanNanLosesComparison(invert_result)
 	'''
 
 	def __init__(self, cc_off=13, cc_n_off=8):
@@ -1583,14 +1587,18 @@ class FConditionDesc(BaseConditionDesc):
 			0b000: 'eq',
 			0b001: 'lt',
 			0b010: 'gt',
+			0b011: 'ltn',
 			0b101: 'gte',
 			0b110: 'lte',
+			0b111: 'gtn',
 
 			0b1000: 'neq',
 			0b1001: 'nlt',
+			0b1011: 'nltn', # unobserved
 			0b1010: 'ngt',
 			0b1101: 'ngte',
 			0b1110: 'nlte',
+			0b1111: 'ngtn', # unobserved
 		}
 
 


### PR DESCRIPTION
Naively, you would implement floating-point min/max as:

fcmpsel lt, A, B, A, B      (A < B ? A : B)

Unfortunately, this is incorrect for NaN. fmin(x, NaN) = fmin(NaN, x) = x but
the above expression may be x or NaN depending on argument order, since NaN < x
is false and x < NaN is.. also false.

To preserve correct floating point behaviour, AGX has two special comparison
modes which act "like" lt/gt but tie break in favour of non-NaN arguments. A
correct implementation of fmin is thus

fcmpsel ltn, A, B, A, B

By the way, what about signed zero? Wikipedia says "min(+0,−0) or min(−0,+0)
must produce something with a value of zero but may always return the first
argument.". Metal's constant folding picks the first argument here. I suppose
these special cases also have a "first wins" tie breaker..

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>