### PR TITLE
applegpu: Support auto LOD with bias

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -4864,9 +4864,8 @@ class LodDesc(OperandDesc):
 				count += 1
 
 			return RegisterTuple(Reg32((value >> 1) + i) for i in range(count))
-
 		else:
-			assert fields['lod'] == 0b110
+			assert fields['lod'] in (0b110, 0b101)
 			return Reg16(value)
 
 class TextureLoadSampleBaseInstructionDesc(InstructionDesc):
@@ -4904,6 +4903,7 @@ class TextureLoadSampleBaseInstructionDesc(InstructionDesc):
 		self.add_operand(EnumDesc('lod', 52, 4, 
 		{
 			0b0000: 'auto_lod',
+			0b0101: 'auto_lod_bias',
 			0b0110: 'lod_min',
 			0b0100: 'lod_grad',
 			0b1100: 'lod_grad_min',

--- a/applegpu.py
+++ b/applegpu.py
@@ -4198,7 +4198,7 @@ class LoadVarDesc(InstructionDesc):
 			0: 'no_centroid',
 			1: 'centroid'
 		}))
-		self.add_operand(ImmediateDesc('q4', 52, 1))
+		self.add_operand(BinaryDesc('kill', 52, 1)) # Kill helper invocations 
 
 @register
 class LoadVarFlatDesc(InstructionDesc):


### PR DESCRIPTION
Example instruction:

  28: 3181404400225f0020000000 texture_sample   0, 0b01, 0b00100, 0b0, 0b00000, xyzw, 0b001, r0_r1_r2_r3, None, ts0, ss0, tex_2d, r0_r1.discard, auto_lod_bias, r2l, 0

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>