### PR TITLE
Remove bogus assertion

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -1946,7 +1946,6 @@ class ThreadgroupMemoryBaseDesc(OperandDesc):
 	def decode_impl(self, fields, allow64):
 		flags = fields[self.name + 't']
 		value = fields[self.name]
-		assert (value & 1) == 0
 		if flags == 0b00:
 			return Reg16(value)
 		elif flags == 0b10:


### PR DESCRIPTION
Value can have the bottom bit set for high 16-bit regs.

  40: 0e0c102008002000     iadd             r3l, 16, r1l.cache, lsl 4
  48: 0e0a202008002000     iadd             r2h, 32, r1l.cache, lsl 4
  50: 0e08302008002000     iadd             r2l, 48, r1l.cache, lsl 4
  58: 0e02002004042000     iadd             r0h, 64, r1l, lsl 4
  60: 69d906c2f781ff03     threadgroup_load i32, quad, r22_r23_r24_r25, r3l, -4
  68: 69c505c2f781ff03     threadgroup_load i32, quad, r17_r18_r19_r20, r2h, -4
  70: 69b504c2f781ff03     threadgroup_load i32, quad, r13_r14_r15_r16, r2l, -4
  78: 69a501c2f781ff03     threadgroup_load i32, quad, r9_r10_r11_r12, r0h, -4

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>