### PR TITLE
Add compiler explorer style msl → agx disassembly tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ hwtestbed/*.metallib
 hwtestbed/*.dylib
 hwtestbed/main
 hwtestbed/cache
+compiler_explorer_tools/metal-archive-extractor
+compiler_explorer_tools/metal-compile-tool
 .DS_Store

--- a/compiler_explorer.py
+++ b/compiler_explorer.py
@@ -1,0 +1,48 @@
+import disassemble
+import subprocess
+import os
+import sys
+import tempfile
+import struct
+
+toolsDir = os.path.join(os.path.dirname(__file__), 'compiler_explorer_tools')
+compileTool = os.path.join(toolsDir, 'metal-compile-tool')
+archiveExtractor = os.path.join(toolsDir, 'metal-archive-extractor')
+
+def read_shader_archive(archiveName):
+	output = []
+	for shaderType in ('vertex', 'fragment', 'compute'):
+		shader = subprocess.check_output([archiveExtractor, '--extract-' + shaderType, '-', archiveName])
+		if shader:
+			output.append((shaderType, shader))
+	return output
+
+if __name__ == '__main__':
+	if not os.path.exists(compileTool):
+		subprocess.run(['make', '-C', toolsDir])
+	if len(sys.argv) == 1:
+		print(f"Usage: python3 {sys.argv[0]} file.metal")
+		exit(1)
+	shaders = None
+	if len(sys.argv) == 2 and os.path.exists(sys.argv[1]):
+		with open(sys.argv[1], "rb") as file:
+			# If the file is a mach-o file, assume it's a compiled shader binary
+			magic = struct.unpack("<I", file.read(4))[0]
+			if magic in (0xcbfebabe, 0xbebafecb, 0xfeedfacf, 0xcffaedfe):
+				shaders = read_shader_archive(sys.argv[1])
+	if not shaders:
+		with tempfile.TemporaryDirectory() as tmpdirname:
+			filename = os.path.join(tmpdirname, 'shader.bin')
+			subprocess.check_output([compileTool, '-o', filename] + sys.argv[1:])
+			shaders = read_shader_archive(filename)
+	for shaderType, shader in shaders:
+		prolog = subprocess.check_output([archiveExtractor, '--extract-prolog-shader', '-', '-'], input=shader)
+		if prolog:
+			print(f"{shaderType} shader prolog:")
+			disassemble.disassemble(prolog)
+			print("")
+		main = subprocess.check_output([archiveExtractor, '--extract-main-shader', '-', '-'], input=shader)
+		if main:
+			print(f"{shaderType} shader:")
+			disassemble.disassemble(main)
+			print("\n")

--- a/compiler_explorer_tools/Makefile
+++ b/compiler_explorer_tools/Makefile
@@ -1,0 +1,12 @@
+all: metal-archive-extractor metal-compile-tool
+
+metal-archive-extractor: metal-archive-extractor.cpp
+	clang -std=c++11 $^ -O2 -o $@
+
+metal-compile-tool: metal-compile-tool.m
+	clang $^ -O2 -framework Metal -framework Cocoa -fobjc-arc -o $@
+
+clean:
+	rm metal-compile-tool metal-archive-extractor
+
+.phony: clean all

--- a/compiler_explorer_tools/metal-archive-extractor.cpp
+++ b/compiler_explorer_tools/metal-archive-extractor.cpp
@@ -1,0 +1,350 @@
+#include <cstdlib>
+#include <cstdio>
+#include <getopt.h>
+#include <mach-o/dyld.h>
+#include <mach-o/fat.h>
+#include <mach-o/nlist.h>
+#include <vector>
+
+#define FAT_MAGIC_METAL 0xcbfebabe
+#define FAT_CIGAM_METAL 0xbebafecb
+
+struct Buffer {
+	void* data;
+	size_t size;
+	bool inBounds(void* ptr) { return static_cast<char*>(ptr) - static_cast<char*>(data) < size; }
+	template <typename T = void>
+	T* offsetPtr(size_t offset) const { return reinterpret_cast<T*>(static_cast<char*>(data) + offset);}
+	operator bool() { return data; }
+};
+
+enum class GPUMachineType {
+	AppleGPU = 0x1000013,
+	AMDGPU   = 0x1000014,
+	IntelGPU = 0x1000015,
+	AIR64    = 0x1000017,
+};
+
+static const char* getMachineTypeName(Buffer buffer) {
+	mach_header_64* mach_header = static_cast<mach_header_64*>(buffer.data);
+	switch (static_cast<GPUMachineType>(mach_header->cputype)) {
+		case GPUMachineType::AppleGPU: return "Apple GPU";
+		case GPUMachineType::AMDGPU:   return "AMD GPU";
+		case GPUMachineType::IntelGPU: return "Intel GPU";
+		default: return "Unknown Target";
+	}
+}
+
+static bool isGPUType(uint32_t machineType) {
+	switch (static_cast<GPUMachineType>(machineType)) {
+		case GPUMachineType::AppleGPU:
+		case GPUMachineType::AMDGPU:
+		case GPUMachineType::IntelGPU:
+			return true;
+		default:
+			return false;
+	}
+}
+
+static uint32_t bswapIfNecessary(bool necessary, uint32_t value) {
+	return necessary ? OSSwapInt32(value) : value;
+}
+
+static Buffer findGPU(Buffer buffer) {
+	fat_header* header = static_cast<fat_header*>(buffer.data);
+	mach_header_64* mach_header = static_cast<mach_header_64*>(buffer.data);
+	if (!buffer.inBounds(header + 1) || !buffer.inBounds(mach_header + 1)) {
+		fprintf(stderr, "File too small for fat header!\n");
+		return {};
+	}
+	bool swap;
+	if (header->magic == FAT_MAGIC_METAL) {
+		swap = false;
+	} else if (header->magic == FAT_CIGAM_METAL) {
+		swap = true;
+	} else if (header->magic == MH_MAGIC_64) {
+		if (isGPUType(static_cast<mach_header_64*>(buffer.data)->cputype)) {
+			return buffer;
+		} else {
+			fprintf(stderr, "File isn't a GPU binary\n");
+			return {};
+		}
+	} else if (header->magic == MH_CIGAM_64) {
+		if (isGPUType(OSSwapInt32(static_cast<mach_header_64*>(buffer.data)->cputype))) {
+			return buffer;
+		} else {
+			fprintf(stderr, "File isn't a GPU binary\n");
+			return {};
+		}
+	} else {
+		fprintf(stderr, "Bad Header Magic %08x\n", header->magic);
+		return {};
+	}
+	uint32_t narch = bswapIfNecessary(swap, header->nfat_arch);
+	fat_arch* archs = reinterpret_cast<fat_arch*>(header + 1);
+	if (!buffer.inBounds(archs + narch)) {
+		fprintf(stderr, "File too small for header!\n");
+		return {};
+	}
+	for (uint32_t i = 0; i < narch; i++) {
+		if (!isGPUType(bswapIfNecessary(swap, archs[i].cputype))) {
+			continue;
+		}
+		uint32_t offset = bswapIfNecessary(swap, archs[i].offset);
+		uint32_t subsize = bswapIfNecessary(swap, archs[i].size);
+		if (buffer.size < offset + subsize) {
+			fprintf(stderr, "Fat header referenced out of bounds area!\n");
+			return {};
+		}
+		return { static_cast<char*>(buffer.data) + offset, subsize };
+	}
+	fprintf(stderr, "Couldn't find any GPU binaries in fat header!\n");
+	return {};
+}
+
+static void* findCommand(Buffer buffer, void* ctx, void* (*isMyCommand)(void* ctx, load_command*)) {
+	mach_header_64* header = static_cast<mach_header_64*>(buffer.data);
+	if (!buffer.inBounds(header + 1)) {
+		fprintf(stderr, "File too small for mach-o header!\n");
+		return nullptr;
+	}
+	if (header->magic == MH_CIGAM_64) {
+		fprintf(stderr, "Non-native-endian mach-o files currently unsupported\n");
+		return nullptr;
+	} else if (header->magic != MH_MAGIC_64) {
+		fprintf(stderr, "Bad mach-o magic\n");
+		return nullptr;
+	}
+	load_command* lc = reinterpret_cast<load_command*>(header + 1);
+	for (uint32_t i = 0; i < header->ncmds; i++, lc = reinterpret_cast<load_command*>(reinterpret_cast<char*>(lc) + lc->cmdsize)) {
+		if (!buffer.inBounds(lc + 1) || !buffer.inBounds(reinterpret_cast<char*>(lc) + lc->cmdsize)) {
+			fprintf(stderr, "Load commands went out of bounds!\n");
+			return {};
+		}
+		if (void* res = isMyCommand(ctx, lc)) {
+			return res;
+		}
+	}
+	return nullptr;
+}
+
+struct FindSectionCtx {
+	Buffer buffer;
+	const char* segment;
+	const char* section;
+};
+
+static void* findSectionHelper(void* vctx, load_command* cmd) {
+	FindSectionCtx* ctx = static_cast<FindSectionCtx*>(vctx);
+	if (cmd->cmdsize < sizeof(segment_command_64) || cmd->cmd != LC_SEGMENT_64) { return nullptr; }
+	segment_command_64* segment = reinterpret_cast<segment_command_64*>(cmd);
+	if (segment->cmdsize < segment->nsects * sizeof(section_64) + sizeof(segment_command_64)) {
+		fprintf(stderr, "Segments %.16s is too small for its section list\n", segment->segname);
+		return nullptr;
+	}
+	section_64* sections = reinterpret_cast<section_64*>(segment + 1);
+	for (uint32_t i = 0; i < segment->nsects; i++) {
+		if (0 != strncmp(ctx->segment, sections[i].segname,  sizeof(sections[i].segname ))) { continue; }
+		if (0 != strncmp(ctx->section, sections[i].sectname, sizeof(sections[i].sectname))) { continue; }
+		if (!ctx->buffer.inBounds(ctx->buffer.offsetPtr(sections[i].offset + sections[i].size))) {
+			fprintf(stderr, "Section %s,%s is out of bounds!\n", ctx->segment, ctx->section);
+			return nullptr;
+		}
+		return &sections[i];
+	}
+	return nullptr;
+}
+
+static section_64* findSection(Buffer buffer, const char* segment, const char* section) {
+	FindSectionCtx ctx { buffer, segment, section };
+	return static_cast<section_64*>(findCommand(buffer, &ctx, findSectionHelper));
+}
+
+static void* isSymtab(void* ctx, load_command* cmd) {
+	if (cmd->cmdsize >= sizeof(symtab_command) && cmd->cmd == LC_SYMTAB) {
+		return cmd;
+	} else {
+		return nullptr;
+	}
+}
+
+static Buffer findSymbol(Buffer buffer, const char* segment, const char* sectionName, const char* symbol) {
+	section_64* section = findSection(buffer, segment, sectionName);
+	if (!section) { return {}; }
+	symtab_command* cmd = reinterpret_cast<symtab_command*>(findCommand(buffer, nullptr, isSymtab));
+	char* strings = buffer.offsetPtr<char>(cmd->stroff);
+	if (!buffer.inBounds(strings + cmd->strsize)) {
+		fprintf(stderr, "String table is out of bounds!\n");
+		return {};
+	}
+	nlist_64* symbols = buffer.offsetPtr<nlist_64>(cmd->symoff);
+	if (!buffer.inBounds(symbols + cmd->nsyms)) {
+		fprintf(stderr, "Symbol table is out of bounds!\n");
+		return {};
+	}
+	uint64_t begin = 0;
+	uint64_t end = 0;
+	for (uint32_t i = 0; i < cmd->nsyms; i++) {
+		uint32_t stroff = symbols[i].n_un.n_strx;
+		if (stroff >= cmd->strsize) {
+			fprintf(stderr, "Symbol %d's name is out of bounds\n", i);
+			continue;
+		}
+		if (0 == strncmp(strings + stroff, symbol, cmd->strsize - stroff)) {
+			if (symbols[i].n_value - section->addr > section->size) {
+				fprintf(stderr, "Symbol %s is not in %s,%s\n", symbol, segment, sectionName);
+				return {};
+			} else {
+				begin = symbols[i].n_value;
+				end = section->size + section->addr;
+				break;
+			}
+		}
+	}
+	if (begin == end) { return {}; }
+	// Assume the symbol ends with the next one
+	for (uint32_t i = 0; i < cmd->nsyms; i++) {
+		if (symbols[i].n_value > begin && symbols[i].n_value < end) {
+			end = symbols[i].n_value;
+		}
+	}
+	return { buffer.offsetPtr(begin - section->addr + section->offset), end - begin };
+}
+
+static FILE* openOrDie(const char* filename, const char* mode) {
+	FILE* output = fopen(filename, mode);
+	if (!output) {
+		fprintf(stderr, "Failed to open %s: %s\n", filename, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+	return output;
+}
+
+static void printUsageAndExit(const char* argv0) {
+	fprintf(stderr, "Usage: %s [--extract-vertex vertex.bin] [--extract-fragment fragment.bin] [--extract-compute compute.bin] binary_archive.bin\n"
+	                "Usage: %s [--extract-prolog-shader prolog.bin] [--extract-main-shader main.bin] agx_shader_archive.bin\n",
+	        argv0, argv0);
+	exit(EXIT_FAILURE);
+}
+
+static void dumpSection(Buffer buffer, const char* filename, const char* segmentName, const char* sectionName) {
+	FILE* file = strcmp(filename, "-") == 0 ? stdout : openOrDie(filename, "wb");
+	if (section_64* section = findSection(buffer, segmentName, sectionName)) {
+		if (!fwrite(buffer.offsetPtr(section->offset), section->size, 1, file)) {
+			fprintf(stderr, "Failed to write to %s: %s\n", filename, strerror(ferror(file)));
+			exit(EXIT_FAILURE);
+		}
+	}
+	if (file != stdout) { fclose(file); }
+}
+
+static void dumpSymbol(Buffer buffer, const char* filename, const char* segmentName, const char* sectionName, const char* symbolName) {
+	FILE* file = strcmp(filename, "-") == 0 ? stdout : openOrDie(filename, "wb");
+	if (Buffer symbol = findSymbol(buffer, segmentName, sectionName, symbolName)) {
+		if (!fwrite(symbol.data, symbol.size, 1, file)) {
+			fprintf(stderr, "Failed to write to %s: %s\n", filename, strerror(ferror(file)));
+			exit(EXIT_FAILURE);
+		}
+	}
+	if (file != stdout) { fclose(file); }
+}
+
+static constexpr option longOpts[] = {
+	{"extract-vertex",         required_argument, nullptr, 'v'},
+	{"extract-fragment",       required_argument, nullptr, 'f'},
+	{"extract-compute",        required_argument, nullptr, 'c'},
+	{"extract-prolog-shader",  required_argument, nullptr, 'p'},
+	{"extract-main-shader",    required_argument, nullptr, 'm'},
+	{nullptr, 0, nullptr, 0}
+};
+
+int main(int argc, char* argv[]) {
+	if (argc <= 1) {
+		printUsageAndExit(argv[0]);
+	}
+	const char* vertex_out = nullptr;
+	const char* fragment_out = nullptr;
+	const char* compute_out = nullptr;
+	const char* prolog_out = nullptr;
+	const char* main_out = nullptr;
+	int c;
+	while ((c = getopt_long(argc, argv, "v:f:c:p:m:", longOpts, nullptr)) > 0) {
+		switch (c) {
+			case 'v':
+				vertex_out = optarg;
+				break;
+			case 'f':
+				fragment_out = optarg;
+				break;
+			case 'c':
+				compute_out = optarg;
+				break;
+			case 'p':
+				prolog_out = optarg;
+				break;
+			case 'm':
+				main_out = optarg;
+				break;
+			case '?':
+				if (!optopt) {
+				} else if (strchr("vfcpm", optopt)) {
+					fprintf(stderr, "Option %c requires an argument!\n", optopt);
+				} else {
+					fprintf(stderr, "Unrecognized argument: %c\n", optopt);
+				}
+				printUsageAndExit(argv[0]);
+		}
+	}
+	bool extract_section = vertex_out || fragment_out || compute_out;
+	bool extract_subsection = prolog_out || main_out;
+	if (extract_section && extract_subsection) {
+		fprintf(stderr, "Can't combine archive extract options and agx extract options!\n");
+		printUsageAndExit(argv[0]);
+	}
+	if (optind >= argc) {
+		fprintf(stderr, "Need a file to extract!\n");
+		printUsageAndExit(argv[0]);
+	}
+
+	FILE* input = strcmp(argv[optind], "-") == 0 ? stdin : openOrDie(argv[optind], "rb");
+	Buffer buffer { malloc(4096), 0 };
+	while (true) {
+		size_t amt = buffer.size < 4096 ? 4096 : buffer.size;
+		size_t read = fread(buffer.offsetPtr(buffer.size), 1, amt, input);
+		buffer.size += read;
+		if (read < amt) { break; }
+		buffer.data = realloc(buffer.data, buffer.size * 2);
+	}
+	if (input != stdin) { fclose(input); }
+
+	Buffer gpu = findGPU(buffer);
+	if (!gpu) { return EXIT_FAILURE; }
+	if (extract_section) {
+		if (vertex_out)   { dumpSection(gpu, vertex_out,   "__TEXT", "__vertex"  ); }
+		if (fragment_out) { dumpSection(gpu, fragment_out, "__TEXT", "__fragment"); }
+		if (compute_out)  { dumpSection(gpu, compute_out,  "__TEXT", "__compute" ); }
+	} else if (extract_subsection) {
+		if (prolog_out) { dumpSymbol(gpu, prolog_out, "__TEXT", "__text", "_agc.main.constant_program"); }
+		if (main_out)   { dumpSymbol(gpu, main_out,   "__TEXT", "__text", "_agc.main"); }
+	} else {
+		printf("Binary for %s\n", getMachineTypeName(gpu));
+		if (findSection(gpu, "__TEXT", "__vertex")) {
+			printf("Contains a vertex shader.\n");
+		}
+		if (findSection(gpu, "__TEXT", "__fragment")) {
+			printf("Contains a fragment shader.\n");
+		}
+		if (findSection(gpu, "__TEXT", "__compute")) {
+			printf("Contains a compute shader.\n");
+		}
+		if (findSymbol(gpu, "__TEXT", "__text", "_agc.main.constant_program")) {
+			printf("Contains an AGX prolog shader\n");
+		}
+		if (findSymbol(gpu, "__TEXT", "__text", "_agc.main")) {
+			printf("Contains an AGX shader\n");
+		}
+	}
+
+	free(buffer.data);
+	return 0;
+}

--- a/compiler_explorer_tools/metal-compile-tool.m
+++ b/compiler_explorer_tools/metal-compile-tool.m
@@ -1,0 +1,205 @@
+#import <Metal/Metal.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#if !__has_feature(objc_arc)
+	#error Please compile with -fobjc-arc
+#endif
+
+static void printUsageAndExit(const char* argv0) {
+	fprintf(stderr, "Usage: %s --output binary_archive.bin shader.metal\n", argv0);
+	exit(EXIT_FAILURE);
+}
+
+static void dieIfError(NSError* err, const char* msg, ...) {
+	if (err) {
+		va_list va;
+		va_start(va, msg);
+		vfprintf(stderr, msg, va);
+		va_end(va);
+		fprintf(stderr, ": %s\n", [[err localizedDescription] UTF8String]);
+		exit(EXIT_FAILURE);
+	}
+}
+
+enum Options {
+	OPTION_NO_FAST_MATH = 128,
+	OPTION_TARGET_FORMAT,
+};
+
+MTLPixelFormat getFormat(const char* name) {
+	static const struct {
+		const char* name;
+		MTLPixelFormat fmt;
+	} formats[] = {
+		{"rgba8unorm",  MTLPixelFormatRGBA8Unorm},
+		{"rgba16float", MTLPixelFormatRGBA16Float},
+		{"rgba16uint",  MTLPixelFormatRGBA16Uint},
+		{"rgba32float", MTLPixelFormatRGBA32Float},
+		{"rgba32uint",  MTLPixelFormatRGBA32Uint},
+		{"r32uint",     MTLPixelFormatR32Uint},
+	};
+	for (size_t i = 0; i < sizeof(formats)/sizeof(*formats); i++) {
+		if (0 == strcasecmp(name, formats[i].name))
+			return formats[i].fmt;
+	}
+	fprintf(stderr, "Unrecognized texture format %s.  Supported formats:\n", name);
+	for (size_t i = 0; i < sizeof(formats)/sizeof(*formats); i++) {
+		fprintf(stderr, "  %s\n", formats[i].name);
+	}
+	exit(EXIT_FAILURE);
+}
+
+static const struct option longOpts[] = {
+	{"output",        required_argument, NULL, 'o'},
+	{"gpu",           required_argument, NULL, 'g'},
+	{"no-fast-math",  no_argument,       NULL, OPTION_NO_FAST_MATH},
+	{"target-format", required_argument, NULL, OPTION_TARGET_FORMAT},
+	{NULL, 0, NULL, 0}
+};
+
+int main(int argc, char* argv[]) {
+	if (argc <= 1) {
+		printUsageAndExit(argv[0]);
+	}
+	BOOL fastMath = YES;
+	const char* output_name = NULL;
+	const char* gpu = NULL;
+	MTLPixelFormat targetFmt = MTLPixelFormatRGBA8Unorm;
+	int c;
+	while ((c = getopt_long(argc, argv, "o:g:", longOpts, NULL)) > 0) {
+		switch (c) {
+			case 'o':
+				output_name = optarg;
+				break;
+			case 'g':
+				gpu = optarg;
+				break;
+			case OPTION_NO_FAST_MATH:
+				fastMath = NO;
+				break;
+			case OPTION_TARGET_FORMAT:
+				targetFmt = getFormat(optarg);
+				break;
+			case '?':
+				if (!optopt) {
+				} else if (strchr("og", optopt)) {
+					fprintf(stderr, "Option %c requires an argument!\n", optopt);
+				} else {
+					fprintf(stderr, "Unrecognized argument: %c\n", optopt);
+				}
+				printUsageAndExit(argv[0]);
+		}
+	}
+	if (!output_name) {
+		fprintf(stderr, "No output file");
+		printUsageAndExit(argv[0]);
+	}
+	if (optind >= argc) {
+		fprintf(stderr, "Need a file to compile!\n");
+		printUsageAndExit(argv[0]);
+	}
+	id<MTLDevice> dev;
+	if (gpu) {
+		for (id<MTLDevice> check in MTLCopyAllDevices()) {
+			if (0 == strncasecmp(gpu, [[check name] UTF8String], strlen(gpu))) {
+				dev = check;
+				break;
+			}
+		}
+	} else {
+		dev = MTLCreateSystemDefaultDevice();
+		if (!dev) {
+			NSArray<id<MTLDevice>>* devs = MTLCopyAllDevices();
+			if ([devs count] > 0) { dev = [devs objectAtIndex:0]; }
+		}
+	}
+	if (!dev) {
+		fprintf(stderr, "Failed to get GPU %s.  Available GPUs:\n", gpu);
+		for (id<MTLDevice> gpu in MTLCopyAllDevices()) {
+			fprintf(stderr, "  %s\n", [[gpu name] UTF8String]);
+		}
+		return EXIT_FAILURE;
+	}
+	NSData* shaderData;
+	NSError* err;
+	if (strcmp(argv[optind], "-") == 0) {
+		shaderData = [[NSFileHandle fileHandleWithStandardInput] readDataToEndOfFile];
+	} else {
+		shaderData = [NSData dataWithContentsOfFile:[NSString stringWithUTF8String:argv[optind]] options:0 error:&err];
+		dieIfError(err, "Failed to read %s", argv[optind]);
+	}
+	id<MTLLibrary> lib = [dev newLibraryWithData:dispatch_data_create([shaderData bytes], [shaderData length], dispatch_get_main_queue(), ^{}) error:nil];
+	if (!lib) {
+		NSString* shader = [[NSString alloc] initWithData:shaderData encoding:NSUTF8StringEncoding];
+		MTLCompileOptions* options = [MTLCompileOptions new];
+		[options setFastMathEnabled:fastMath];
+		lib = [dev newLibraryWithSource:shader options:options error:&err];
+	}
+	dieIfError(err, "Failed to compile shaders");
+	id<MTLFunction> vs, fs, cs;
+	for (NSString* name in [lib functionNames]) {
+		id<MTLFunction> fn = [lib newFunctionWithName:name];
+		if (!fn) {
+			fprintf(stderr, "Failed to make function %s\n", [name UTF8String]);
+			return EXIT_FAILURE;
+		}
+		switch ([fn functionType]) {
+			case MTLFunctionTypeVertex:
+				if (vs) {
+					fprintf(stderr, "Only one vertex shader is allowed! (Got both %s and %s)\n", [[vs name] UTF8String], [name UTF8String]);
+					return EXIT_FAILURE;
+				}
+				vs = fn;
+				break;
+			case MTLFunctionTypeFragment:
+				if (fs) {
+					fprintf(stderr, "Only one fragment shader is allowed! (Got both %s and %s)\n", [[fs name] UTF8String], [name UTF8String]);
+					return EXIT_FAILURE;
+				}
+				fs = fn;
+				break;
+			case MTLFunctionTypeKernel:
+				if (cs) {
+					fprintf(stderr, "Only one compute shader is allowed! (Got both %s and %s)\n", [[cs name] UTF8String], [name UTF8String]);
+					return EXIT_FAILURE;
+				}
+				cs = fn;
+				break;
+			default:
+				fprintf(stderr, "Function %s is of unsupported type %lu\n", [name UTF8String], (unsigned long)[fn functionType]);
+				return EXIT_FAILURE;
+		}
+	}
+	if (!vs && !fs && !cs) {
+		fprintf(stderr, "No shaders found\n");
+		return EXIT_FAILURE;
+	}
+	id<MTLBinaryArchive> arc = [dev newBinaryArchiveWithDescriptor:[MTLBinaryArchiveDescriptor new] error:&err];
+	dieIfError(err, "Failed to make binary archive");
+	if (vs || fs) {
+		MTLRenderPipelineDescriptor* desc = [MTLRenderPipelineDescriptor new];
+		[desc setVertexFunction:vs];
+		[desc setFragmentFunction:fs];
+		[[desc colorAttachments][0] setPixelFormat:targetFmt];
+		[arc addRenderPipelineFunctionsWithDescriptor:desc error:&err];
+		if (err) {
+			if (vs && fs) {
+				dieIfError(err, "Failed to add render pipeline with %s and %s", [[vs name] UTF8String], [[fs name] UTF8String]);
+			} else {
+				dieIfError(err, "Failed to add render pipeline with %s", [[(vs ? vs : fs) name] UTF8String]);
+			}
+		}
+	}
+	if (cs) {
+		MTLComputePipelineDescriptor* desc = [MTLComputePipelineDescriptor new];
+		[desc setComputeFunction:cs];
+		[arc addComputePipelineFunctionsWithDescriptor:desc error:&err];
+		dieIfError(err, "Failed to add render pipeline with %s", [[cs name] UTF8String]);
+	}
+	[arc serializeToURL:[NSURL fileURLWithPath:[NSString stringWithCString:output_name encoding:NSUTF8StringEncoding]]
+	              error:&err];
+	dieIfError(err, "Failed to write %s", output_name);
+	return 0;
+}

--- a/disassemble.py
+++ b/disassemble.py
@@ -44,13 +44,13 @@ def disassemble(code):
 		assert length >= 2 and length % 2 == 0
 		p += length
 
-
-if len(sys.argv) > 1:
-	f = open(sys.argv[1], 'rb')
-	if len(sys.argv) > 2:
-		f.seek(int(sys.argv[2], 0))
-	code = f.read()
-	disassemble(code)
-else:
-	print('usage: python3 disassemble.py [filename] [offset]')
-	exit(1)
+if __name__ == '__main__':
+	if len(sys.argv) > 1:
+		f = open(sys.argv[1], 'rb')
+		if len(sys.argv) > 2:
+			f.seek(int(sys.argv[2], 0))
+		code = f.read()
+		disassemble(code)
+	else:
+		print('usage: python3 disassemble.py [filename] [offset]')
+		exit(1)


### PR DESCRIPTION
Single-program solution for compiling MSL to an AGX binary, then disassembling it
(Also supports metallibs and compiled Metal binary archives as inputs in case you want to customize the compilation process a bit more)

Example Input:
```bash
echo "kernel void test(uint3 pos [[thread_position_in_grid]], metal::texture2d<half> tex, device half4* out) { out[pos.x] = tex.read(pos.xy, pos.z); }" | python3 compiler_explorer.py -
```
Example Output:
```
compute shader prolog:
   0: 0e01881900000000     isub             r0, u4, 1
   8: c500a03d00803000     uniform_store    2, i16, pair, 0, r0l_r0h, 10
  10: 8800                 stop             

compute shader:
   0: f2091004             get_sr           r2.cache, sr80 (thread_position_in_grid.x)
   4: f20d1204             get_sr           r3.cache, sr82 (thread_position_in_grid.z)
   8: 72051104             get_sr           r1, sr81 (thread_position_in_grid.y)
   c: 120146a2188c4144     icmpsel          ugt, r0, r3, u5, u6, r2
  14: 7100404600626f00     texture_load     0, 0b01, 0b01100, 0b0, 0b00000, xyzw, 0b000, r0l_r0h_r1l_r1h, None, ts0, ss0, tex_2d, r0_r1.discard, lod_min, r3l
  1c: 3800                 wait             0
  1e: c500400e00c8f000     device_store     0, i16, quad, r0l_r0h_r1l_r1h, u0_u1, r2, unsigned, lsl 2, 0
  26: 8800                 stop             
```