### PR TITLE
Add (pixel) image write instruction

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -5443,8 +5443,7 @@ class PBESourceRegDesc(OperandDesc):
 		super().__init__(name)
 		self.add_merged_field(self.name, [
 			(9, 6, self.name),
-			# TODO: where is the extension?
-			#(60, 2, self.name + 'x'),
+			(56, 2, self.name + 'x'),
 		])
 		self.add_field(8, 1, self.name + 't')
 
@@ -5467,9 +5466,9 @@ class ImageWrite(MaskedInstructionDesc):
 		self.add_constant(0, 8, 0xF1)
 
 		self.add_operand(PBESourceRegDesc('R'))
-		self.add_operand(CoordsDesc('C', offx=58)) # TODO: figure out actual extend
+		self.add_operand(CoordsDesc('C', offx=58))
 		self.add_operand(PBELodDesc('D'))
-		self.add_operand(TextureDesc('T', offx=56)) # TODO: figure out actual extend
+		self.add_operand(TextureDesc('T', offx=62))
 		self.add_operand(EnumDesc('n', [
 			(40, 3, 'n'),
 			#TODO: extend bit?
@@ -5477,7 +5476,7 @@ class ImageWrite(MaskedInstructionDesc):
 		], None, TEX_TYPES))
 
 		self.add_operand(EnumDesc('round', 53, 1, {
-			0: 'rte' # round to nearest [or writing integers]
+			0: 'rte', # round to nearest [or writing integers]
 			1: 'rtz', # round to zero
 		}))
 
@@ -5487,7 +5486,6 @@ class ImageWrite(MaskedInstructionDesc):
 		self.add_operand(ImmediateDesc('u3', 43, 4))  # 9
 		self.add_operand(ImmediateDesc('u4', 47, 6))  # 0
 		self.add_operand(ImmediateDesc('u5', 54, 2))  # 0
-		self.add_operand(ImmediateDesc('u6', 62, 2))  # 0
 
 @register
 class TodoSrThingInstructionDesc(MaskedInstructionDesc):

--- a/applegpu.py
+++ b/applegpu.py
@@ -5161,13 +5161,14 @@ TEX_SIZES = {
 }
 
 class CoordsDesc(OperandDesc):
-	def __init__(self, name, off=16, offx=74, offt=22):
+	def __init__(self, name, off=16, offx=74, offt=22, offs=47):
 		super().__init__(name)
 		self.add_merged_field(self.name, [
 			(off, 6, self.name),
 			(offx, 2, self.name + 'x'),
 		])
 		self.add_field(offt, 1, self.name + 't')
+		self.add_field(offs, 1, self.name + 's')
 
 	def decode(self, fields):
 		flags = fields[self.name + 't']
@@ -5175,8 +5176,10 @@ class CoordsDesc(OperandDesc):
 
 		count, extra = TEX_SIZES[fields['n']]
 
-		# not really clear how the alignment requirement works
-		if extra:
+		if fields[self.name + 's'] != 0:
+			t = RegisterTuple(Reg16((value) + i) for i in range(count + extra))
+		elif extra:
+			# not really clear how the alignment requirement works
 			t = RegisterTuple(Reg16((value) + i) for i in range(count * 2 + 1))
 		else:
 			t = RegisterTuple(Reg32((value >> 1) + i) for i in range(count))
@@ -5249,7 +5252,7 @@ class TextureLoadSampleBaseInstructionDesc(InstructionDesc):
 		self.add_operand(ImmediateDesc('compare', 23, 1))
 		# unknowns
 		self.add_operand(BinaryDesc('q2', 30, 2))
-		self.add_operand(BinaryDesc('q3', 43, 5))
+		self.add_operand(BinaryDesc('q3', 43, 4))
 		self.add_operand(BinaryDesc('slot', 63, 1)) # slot to pass to wait
 
 		# Bottom bit set with compares?
@@ -5484,7 +5487,7 @@ class ImageWrite(MaskedInstructionDesc):
 		self.add_operand(ImmediateDesc('u1', 23, 1))  # 1
 		self.add_operand(ImmediateDesc('u2', 30, 1))  # 0
 		self.add_operand(ImmediateDesc('u3', 43, 4))  # 9
-		self.add_operand(ImmediateDesc('u4', 47, 6))  # 0
+		self.add_operand(ImmediateDesc('u4', 48, 5))  # 0
 		self.add_operand(ImmediateDesc('u5', 54, 2))  # 0
 
 @register

--- a/applegpu.py
+++ b/applegpu.py
@@ -5052,7 +5052,7 @@ class SampleURegDesc(OperandDesc):
 
 	def decode(self, fields):
 		v = fields[self.name]
-		if fields['Tt'] & 1:
+		if fields['Tt'] & 2:
 			return UReg64(v * 2)
 		else:
 			return None
@@ -5079,15 +5079,19 @@ class TextureDesc(OperandDesc):
 		value = fields[self.name]
 
 		if flags == 0b0:
+			# Immediate texture state
 			return TextureState(value)
 		elif flags == 0b01:
+			# Indirect texture state
 			return Reg16(value)
 		elif flags == 0b10:
+			# Bindless, unknown. Maybe a 16-bit register offset.
 			if value == 0:
-				return Immediate(0)
+				return Immediate(0) # How can this be right?
 			else:
 				return Reg16(value)
 		elif flags == 0b11:
+			# Bindless 64-bit uniform + 32-bit offset
 			return Reg32(value >> 1)
 
 	def encode_string(self, fields, opstr):

--- a/applegpu.py
+++ b/applegpu.py
@@ -5471,11 +5471,11 @@ class ImageWrite(MaskedInstructionDesc):
 		self.add_operand(PBESourceRegDesc('R'))
 		self.add_operand(CoordsDesc('C', offx=58))
 		self.add_operand(PBELodDesc('D'))
+		self.add_operand(SampleURegDesc('U', 48, 5))
 		self.add_operand(TextureDesc('T', offx=62))
 		self.add_operand(EnumDesc('n', [
 			(40, 3, 'n'),
-			#TODO: extend bit?
-			#(71, 1, 'nx')
+			(55, 1, 'nx')
 		], None, TEX_TYPES))
 
 		self.add_operand(EnumDesc('round', 53, 1, {
@@ -5487,8 +5487,7 @@ class ImageWrite(MaskedInstructionDesc):
 		self.add_operand(ImmediateDesc('u1', 23, 1))  # 1
 		self.add_operand(ImmediateDesc('u2', 30, 1))  # 0
 		self.add_operand(ImmediateDesc('u3', 43, 4))  # 9
-		self.add_operand(ImmediateDesc('u4', 48, 5))  # 0
-		self.add_operand(ImmediateDesc('u5', 54, 2))  # 0
+		self.add_operand(ImmediateDesc('u5', 54, 1))  # 0
 
 @register
 class TodoSrThingInstructionDesc(MaskedInstructionDesc):


### PR DESCRIPTION
Shader images, wee! This executes on the PBE unit, you pass it a PBE descriptor pointed to by the texture state instead of a texture descriptor. Same as with TODO.unkB1 (block image write) which also executes on the PBE, but doesn't take value/coordinates/LOD? so has a somewhat different encoding.

TODOs ideally before merge

- [ ] extend bits (missing/wrong), again I'm doing this all without tools
- [x] texture write rounding mode bit, I think it's what I called "f" here but my Xcode setup is too broken for me to find out, someone with a full Xcode install should see what happens when setting `-ftexture-write-rounding-mode={native,rtz,rte}` when compiling shaders.