### PR TITLE
FBinaryInstructions have compressed encodings

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -3137,9 +3137,8 @@ class FMAdd16InstructionDesc(FSaturatableInstructionDesc):
 
 class FBinaryInstructionDesc(FSaturatableInstructionDesc):
 	def __init__(self, name, opcode):
-		super().__init__(name, size=6)
+		super().__init__(name, size=(4,6))
 		self.add_constant(0, 6, opcode)
-		self.add_constant(15, 1, 1)
 
 		self.add_operand(FloatDstDesc('D', 44))
 
@@ -3148,9 +3147,8 @@ class FBinaryInstructionDesc(FSaturatableInstructionDesc):
 
 class F16BinaryInstructionDesc(FSaturatableInstructionDesc):
 	def __init__(self, name, opcode):
-		super().__init__(name, size=6)
+		super().__init__(name, size=(4,6))
 		self.add_constant(0, 6, opcode)
-		self.add_constant(15, 1, 1)
 
 		# TODO: what if dest isn't 16-bit?
 		self.add_operand(FloatDst16Desc('D', 44))


### PR DESCRIPTION
Yes, the compiler will generate them
Yes, they're as useless as they sound (the Bt and the upper bits of the B field are forced to zero, so you can only use them with the constants 0/64 to 15/64)

When compiled with fast math off...
```metal
kernel void yay(uint u [[thread_position_in_grid]], device float2* fout, device half2* hout, const device float* fin, const device half* hin) {
	fout[u] = float2(fin[u] * 0.f, fin[u] + 0.f);
	hout[u] =  half2(hin[u] * 0.h, hin[u] + 0.h);
}
```
```
   0: 72091004             get_sr           r2, sr80 (thread_position_in_grid.x)
   4: 0509480e00c01200     device_load      0, i32, x, r1, u4_u5, r2, unsigned
   c: 3800                 wait             0
   e: 1a018202             fmul32           r0, r1.cache, 0.0
  12: 2a05c202             fadd32           r1, r1.discard, 0.0
  16: 4501400e00c43200     device_store     0, i32, xy, r0_r1, u0_u1, r2, unsigned, lsl 1, 0
  1e: 85044c0e00c01000     device_load      0, i16, x, r0h, u6_u7, r2, unsigned
  26: 3800                 wait             0
  28: 16008100             fmul16           r0l, r0h.cache, 0.0
  2c: 2602c100             fadd16           r0h, r0h.discard, 0.0
  30: c500440e00c43000     device_store     0, i16, xy, r0l_r0h, u2_u3, r2, unsigned, lsl 1, 0
  38: 8800                 stop             
```
Or with fast math on...
```metal
kernel void yay(uint u [[thread_position_in_grid]], device float2* fout, device half2* hout, const device float* fin, const device half* hin) {
	fout[u] = float2(fin[u] * (15.f/64.f), fin[u] + (15.f/64.f));
	hout[u] =  half2(hin[u] * (15.h/64.h), hin[u] + (15.h/64.h));
}
```
```
   0: 72091004             get_sr           r2, sr80 (thread_position_in_grid.x)
   4: 0509480e00c01200     device_load      0, i32, x, r1, u4_u5, r2, unsigned
   c: 3800                 wait             0
   e: 1a0182f2             fmul32           r0, r1.cache, 0.234375
  12: 2a05c2f2             fadd32           r1, r1.discard, 0.234375
  16: 4501400e00c43200     device_store     0, i32, xy, r0_r1, u0_u1, r2, unsigned, lsl 1, 0
  1e: 85044c0e00c01000     device_load      0, i16, x, r0h, u6_u7, r2, unsigned
  26: 3800                 wait             0
  28: 160081f0             fmul16           r0l, r0h.cache, 0.234375
  2c: 2602c1f0             fadd16           r0h, r0h.discard, 0.234375
  30: c500440e00c43000     device_store     0, i16, xy, r0l_r0h, u2_u3, r2, unsigned, lsl 1, 0
  38: 8800                 stop             
```