### PR TITLE
Handle pixel fence wait/signal instructions

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -4344,12 +4344,17 @@ for op, mnem in [
 	instruction_descriptors.append(o)
 
 
-o = InstructionDesc('writeout', size=4)
+o = InstructionDesc('wait_pix', size=4)
 o.add_constant(0, 8, 0b01001000)
-o.add_operand(ImmediateDesc('i', 8, 10)) # x: 26,2
-o.add_operand(ImmediateDesc('j', 22, 2)) # x: 26,2
+o.add_operand(ImmediateDesc('i', 8, 10))
+o.add_operand(ImmediateDesc('j', 22, 2))
 instruction_descriptors.append(o)
 
+o = InstructionDesc('signal_pix', size=4)
+o.add_constant(0, 8, 0b01011000)
+o.add_operand(ImmediateDesc('i', 8, 10))
+o.add_operand(ImmediateDesc('j', 22, 2))
+instruction_descriptors.append(o)
 
 # wait for a load
 @register


### PR DESCRIPTION
In my current understanding, each pixel has a number of associated fences. From the perspective of a pixel shader invocation P, a fence is completed when every older pixel shader invocation P' shading the same pixel (due to overdraw in the scene) has signalled the fence or completed execution. This includes the vacuous case when there is no overdraw. A given pixel shader can wait for this condition (wait_pix with the desired fence ID) and can signal to other pixels that it's safe to proceed. This mechanism can be used to implement rasterizer-ordered views and fragment shader interlock, but in its most basic form it's just required to properly order writes to the tilebuffer.