### PR TITLE
Add interleave instruction

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -2836,6 +2836,17 @@ class IUnaryInstructionDesc(MaskedInstructionDesc):
 
 		self.add_constant(28, 10, 0)
 
+class IBinaryInstructionDesc(MaskedInstructionDesc):
+	def __init__(self, name):
+		super().__init__(name, size=6)
+		self.add_constant(0, 7, 0b0111110)
+		self.add_constant(15, 1, 0)
+
+		self.add_operand(ALUDstDesc('D', 44))
+		self.add_operand(ALUSrcDesc('A', 16, 42))
+		self.add_operand(ALUSrcDesc('B', 28, 40))
+
+
 
 @register
 class BitopInstructionDesc(MaskedInstructionDesc):
@@ -3009,6 +3020,35 @@ class PopCountInstructionDesc(IUnaryInstructionDesc):
 				result += 1
 
 		self.operands['D'].set_thread(fields, corestate, thread, result)
+
+
+
+@register
+class InterleaveInstructionDesc(IBinaryInstructionDesc):
+	documentation_name = 'INTerLeave bits (Morton encode)'
+
+	pseudocode = '''
+	for each active thread:
+		a = A[thread]
+		b = B[thread]
+
+		result = 0
+
+		i = 0
+		for i in range(16):
+			if a & (1 << i):
+				result |= (1 << (2 * i))
+
+			if b & (1 << i):
+				result |= (1 << ((2 * i) + 1))
+
+		D[thread] = result
+	'''
+
+	def __init__(self):
+		super().__init__('intl')
+		self.add_constant(38, 2, 0b00)
+		self.add_constant(26, 2, 0b00)
 
 @register
 class FindFirstSetInstructionDesc(IUnaryInstructionDesc):


### PR DESCRIPTION
Dougall and I determined the encoding by symmetry with other bit scan
instructions (ffs, bitrev, and nebulously popcount). To confirm the
behaviour, I hacked the compiler to replace imul with interleave, and
then wrote the following shader-runner test to check every pair of
16-bit inputs, which passes in under a second on M1:

    [require]
    GL ES >= 3.1
    GLSL ES >= 3.10

    [compute shader]
    #version 310 es

    layout (local_size_x = 32, local_size_y = 1) in;
    layout(binding = 0) uniform atomic_uint good;
    layout(binding = 0) uniform atomic_uint bad;

    uint reference(uint x, uint y) {
        uint z = 0u;
        for (uint i = 0u; i < 16u; ++i) {
            z |= ((x & (1u << i)) << i);
            z |= ((y & (1u << i)) << (i + 1u));
        }
        return z;
    }

    uint result(uint x, uint y) {
        /* overloaded */
        return x * y;
    }

    void main (void)
    {
        uint x = uint(gl_GlobalInvocationID.x);
        bool allOk = true;

        for (uint y = 0u; y < 65536u; ++y) {
            if ((reference(x, y) != result(x, y)))
                allOk = false;
        }

        if (allOk)
            atomicCounterIncrement(good);
        else
            atomicCounterIncrement(bad);
    }

    [test]
    atomic counters 2

    compute 2048 1 1

    probe atomic counter 0 == 65536
    probe atomic counter 1 == 0

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>