### PR TITLE
Add rtz memory formats

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -4499,6 +4499,8 @@ MEMORY_FORMATS = {
 
 	12: 'rg11b10f',  # size = 1
 	13: 'rgb9e5',    # size = 1
+	14: 'rg11b10f.rtz', # size = 1
+	15: 'rgb9e5.rtz',   # size = 1
 
 	# TODO: others?
 }


### PR DESCRIPTION
Apparently there's a few extra memory formats for `st_tile` to pick between different rounding modes

Apple's GPU compiler responds to the `-ftexture-write-rounding-mode` of the associated shader when generating framebuffer output code, and uses it to pick between the instructions (but only if your shader outputs a `float4`, not `half4` for some reason).

I've only tested the things the Apple compiler outputs, so no clue if these formats work with other instructions (or even float16s for that matter)

<details>
<summary>Test program</summary>

To run:
`xcrun metal Shaders.metal -ftexture-write-rounding-mode=(rtz|rte) -o Shaders.metallib`
`swiftc -O TestProgram.swift`
`./TestProgram Shaders.metallib`
The test program will write binary archives to `/tmp/Pipe_$GPUNAME_{RG11B10F,RGB9E5}.bin` for you to disassemble with `compiler_explorer.py`

Shaders:
```metal
#include <metal_stdlib>
using namespace metal;

struct V2F {
	float4 pos [[position]];
	float4 col;
};

vertex V2F vs(uint vid [[vertex_id]]) {
	return {
		float4(vid == 1 ? 3 : -1, vid == 2 ? 3 : -1, 0, 1),
		float2(vid == 1 ? 2 : 0, 1).xxxy,
	};
}

fragment float4 fs(V2F in [[stage_in]]) {
	return in.col;
}
```
Test Program:
```swift
import Metal

func decodeRGB9E5(_ data: UInt32) -> SIMD3<Float> {
	let exponent = exp2(Float(Int32(data >> 27) - (9 + 15)))
	let mantissa = SIMD3<UInt32>(data & 0x1ff, (data >> 9) & 0x1ff, (data >> 18) & 0x1ff)
	return SIMD3<Float>(mantissa) * exponent
}

func decodeRG11B10(_ data: UInt32) -> SIMD3<Float> {
	let r = Float16(bitPattern: UInt16((data << 4) & 0x7ff0))
	let g = Float16(bitPattern: UInt16((data >> 7) & 0x7ff0))
	let b = Float16(bitPattern: UInt16((data >> 17) & 0x7fe0))
	return SIMD3<Float>(SIMD3(r, g, b))
}

if CommandLine.arguments.count <= 1 {
	fputs("Usage: \(CommandLine.arguments[0]) library.metallib\n", stderr)
	exit(EXIT_FAILURE)
}

for gpu in MTLCopyAllDevices() {
	let lib = try gpu.makeLibrary(URL: URL(fileURLWithPath: CommandLine.arguments[1]))
	let pdesc = MTLRenderPipelineDescriptor()
	pdesc.vertexFunction = lib.makeFunction(name: "vs")!
	pdesc.fragmentFunction = lib.makeFunction(name: "fs")!
	let width = 1024
	let tdesc = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .invalid, width: width, height: 1, mipmapped: false)
	tdesc.storageMode = .private
	tdesc.usage = .renderTarget
	let rpdesc = MTLRenderPassDescriptor()
	rpdesc.colorAttachments[0].loadAction = .dontCare
	rpdesc.colorAttachments[0].storeAction = .store
	let buf = gpu.makeBuffer(length: width * 4)!
	let q = gpu.makeCommandQueue()!
	for fmt: MTLPixelFormat in [.rgb9e5Float, .rg11b10Float] {
		let fmtName = fmt == .rgb9e5Float ? "RGB9E5" : "RG11B10F"
		tdesc.pixelFormat = fmt
		pdesc.colorAttachments[0].pixelFormat = fmt
		let tex = gpu.makeTexture(descriptor: tdesc)!
		let pipe = try gpu.makeRenderPipelineState(descriptor: pdesc)
		rpdesc.colorAttachments[0].texture = tex
		let cb = q.makeCommandBuffer()!
		do {
			let enc = cb.makeRenderCommandEncoder(descriptor: rpdesc)!
			enc.setRenderPipelineState(pipe)
			enc.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
			enc.endEncoding()
		}
		do {
			let enc = cb.makeBlitCommandEncoder()!
			enc.copy(
				from: tex,
				sourceSlice: 0,
				sourceLevel: 0,
				sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
				sourceSize: MTLSize(width: width, height: 1, depth: 1),
				to: buf,
				destinationOffset: 0,
				destinationBytesPerRow: width * 4,
				destinationBytesPerImage: width * 4
			)
			enc.endEncoding()
		}
		cb.commit()
		cb.waitUntilCompleted()
		let ptr = UnsafeBufferPointer(start: buf.contents().bindMemory(to: UInt32.self, capacity: width), count: width)
		let arc = try gpu.makeBinaryArchive(descriptor: .init())
		try arc.addRenderPipelineFunctions(descriptor: pdesc)
		try arc.serialize(to: URL(fileURLWithPath: "/tmp/Pipe_\(gpu.name)_\(fmtName).bin"))
		print("Format: \(fmtName)")
		for (idx, elem) in ptr[0..<width * 3 / 4].enumerated() {
			var col = fmt == .rgb9e5Float ? decodeRGB9E5(elem) : decodeRG11B10(elem)
			col *= Float(width)
			print(String(format: "%4d: %08x %5.1f %5.1f %5.1f", idx, elem, col.x, col.y, col.z))
		}
	}
}
```
</details>

<details>
<summary>RTZ output</summary>

RGB9E5:
```
   0: 618101c000401000     iterproj         r0_r1_r2, cf1, cf0, elide, center, 0b1, 0, 0, 0, 0, 0, 0
   8: 4800c200             wait_pix         512, 3
   c: 480c0000             wait_pix         12, 0
  10: 0901000f70fc0003     st_tile          r0_r1_r2, rgb9e5.rtz, 0, xyz, 0, 255, 0
  18: 8800                 stop             
```
RG11B10F:
```
   0: 618101c000401000     iterproj         r0_r1_r2, cf1, cf0, elide, center, 0b1, 0, 0, 0, 0, 0, 0
   8: 4800c200             wait_pix         512, 3
   c: 480c0000             wait_pix         12, 0
  10: 0901000e70fc0003     st_tile          r0_r1_r2, rg11b10f.rtz, 0, xyz, 0, 255, 0
  18: 8800                 stop             
```
[Output](https://github.com/dougallj/applegpu/files/12820993/RTZ.txt)
</details>

<details>
<summary>RTE output</summary>

RGB9E5:
```
   0: 618101c000401000     iterproj         r0_r1_r2, cf1, cf0, elide, center, 0b1, 0, 0, 0, 0, 0, 0
   8: 4800c200             wait_pix         512, 3
   c: 480c0000             wait_pix         12, 0
  10: 0901000d70fc0003     st_tile          r0_r1_r2, rgb9e5, 0, xyz, 0, 255, 0
  18: 8800                 stop             
```
RG11B10F:
```
   0: 618101c000401000     iterproj         r0_r1_r2, cf1, cf0, elide, center, 0b1, 0, 0, 0, 0, 0, 0
   8: 4800c200             wait_pix         512, 3
   c: 480c0000             wait_pix         12, 0
  10: 0901000c70fc0003     st_tile          r0_r1_r2, rg11b10f, 0, xyz, 0, 255, 0
  18: 8800                 stop             
```
[Output](https://github.com/dougallj/applegpu/files/12821010/RTE.txt)
</details>

Side note: It seems the rgb9e5 rte doesn't work quite right (look at around 256 in the RTE output), and tie-breaks positive instead of towards even