### PR TITLE
Add sampler_state_store

### DIFF
--- a/applegpu.py
+++ b/applegpu.py
@@ -4822,6 +4822,40 @@ class StoreToTextureStateInstructionDesc(InstructionDesc):
 		self.add_operand(UReg64Desc('B', 58, 6))
 		self.add_operand(Reg32Desc('O', 27, 7))
 
+class SamplerStateDestDesc(OperandDesc):
+	def __init__(self, name, off=8):
+		super().__init__(name)
+		self.add_field(off, 5, self.name)
+
+	def decode(self, fields):
+		return SamplerState(fields[self.name])
+
+	def encode_string(self, fields, opstr):
+		r = try_parse_register(opstr)
+		if isinstance(r, SamplerState):
+			value = r.n
+			flags = 0
+		else:
+			raise Exception('invalid TextureStateDestDesc %r' % (opstr,))
+
+		fields[self.name] = value
+
+@register
+class StoreToSamplerStateInstructionDesc(InstructionDesc):
+	documentation_html = '''
+	<p>
+	<code>sampler_state_store</code> is used to initialize sampler state registers.
+	The sampler descriptor at <code>B + O</code> is stored into sampler state register <code>SS</code>.
+	</p>
+	'''
+	def __init__(self):
+		super().__init__('sampler_state_store', size=8)
+		self.add_constant(0, 8, 0b10101101)
+		self.add_constant(20, 1, 1)
+		self.add_operand(SamplerStateDestDesc('SS'))
+		self.add_operand(UReg64Desc('B', 58, 6))
+		self.add_operand(Reg32Desc('O', 27, 7))
+
 for op, mnem in [
 	(0b01010001, 'no_var'),
 	(0b00010001, 'st_var'),


### PR DESCRIPTION
"it stands to reason there should also be a `sampler_state_store` instruction, did you check for that?" - Alyssa, after seeing the `tex_state_store` instruction
A few random opcode bitflips later, I can confirm that she was correct.

I haven't tested how it handles when the ss registers are set to extended

<details>
<summary>Test Harness</summary>

Loads from tex5 at the coordinates (0, 0) through (15/4, 15/4) using three different samplers.
tex0 receives a filter=nearest, wrap=clampToEdge, normalized coordinate sample
tex2 receives a filter=linear, wrap=clampToEdge, normalized coordinate sample
tex4 receives a filter=linear, wrap=clampToEdge, pixel coordinate sample
```swift
import Metal

let shader = """
using namespace metal;

struct ArgBuf {
	texture2d<float, access::read_write> tex[6];
	sampler samp;
};

struct DescSetList {
	constant ArgBuf& args;
};

kernel void test(uint2 idx [[thread_position_in_grid]], constant DescSetList& sets [[buffer(0)]], constant uint* texlist [[buffer(1)]], texture2d<float, access::write> otex [[texture(0)]], texture2d<float> itex [[texture(1)]], sampler samp0 [[sampler(0)]], sampler samp1 [[sampler(1)]]) {
	constant ArgBuf& args = sets.args;
	float2 coord = float2(idx) / 4;
	args.tex[texlist[0]].write(itex.sample(samp0, coord), idx);
	args.tex[texlist[1]].write(itex.sample(samp1, coord), idx);
	otex.write(itex.sample(args.samp, coord), idx);
}
"""

extension MTLSamplerDescriptor {
	func setFilter(_ filter: MTLSamplerMinMagFilter) {
		minFilter = filter
		magFilter = filter
	}
}

let path = URL(fileURLWithPath: "/tmp/SSStoreTest.metallib")

func writeShaderAndExit(lib: MTLLibrary) throws -> Never {
	let cdesc = MTLComputePipelineDescriptor()
	cdesc.computeFunction = lib.makeFunction(name: "test")!
	try? FileManager.default.removeItem(at: path)
	let archive = try lib.device.makeBinaryArchive(descriptor: .init())
	try archive.addComputePipelineFunctions(descriptor: cdesc)
	try archive.serialize(to: path)
	print("Wrote shader to \(path.path).  Please modify it for testing and rerun.")
	exit(EXIT_FAILURE)
}

if let gpu = MTLCopyAllDevices().first(where: { $0.supportsFamily(.apple1) }) {
	let lib = try gpu.makeLibrary(source: shader, options: nil)
	guard FileManager.default.fileExists(atPath: path.path) else {
		try writeShaderAndExit(lib: lib)
	}
	let pipe: MTLComputePipelineState
	do {
		let cdesc = MTLComputePipelineDescriptor()
		cdesc.computeFunction = lib.makeFunction(name: "test")!
		let archiveDesc = MTLBinaryArchiveDescriptor()
		archiveDesc.url = path
		let archive = try gpu.makeBinaryArchive(descriptor: archiveDesc)
		cdesc.binaryArchives = [archive]
		pipe = try gpu.makeComputePipelineState(descriptor: cdesc, options: .failOnBinaryArchiveMiss).0
	} catch {
		print("Failed to load shader: \(error.localizedDescription)")
		print("Generating new metallib...")
		try writeShaderAndExit(lib: lib)
	}
	let queue = gpu.makeCommandQueue()!
	let sdesc = MTLSamplerDescriptor()
	sdesc.normalizedCoordinates = true
	sdesc.setFilter(.nearest)
	let s0 = gpu.makeSamplerState(descriptor: sdesc)!
	sdesc.setFilter(.linear)
	let s1 = gpu.makeSamplerState(descriptor: sdesc)!
	sdesc.normalizedCoordinates = false
	sdesc.supportArgumentBuffers = true
	let s2 = gpu.makeSamplerState(descriptor: sdesc)!
	let tdesc = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba8Unorm, width: 16, height: 16, mipmapped: false)
	tdesc.storageMode = .shared
	tdesc.usage = [.shaderRead, .shaderWrite]
	let textures = (0..<6).map { _ in gpu.makeTexture(descriptor: tdesc)! }
	let sampdesc: [UInt32] = [
		// See mesa asahi/genxml/cmdbuf.xml sampler struct
		// filter=linear wrap_s=clamp_to_border wrap_t=clamp_to_edge, pixel coordinates
		0x62800000,
		0x00000040,
		0,
		0,
		0,
		0,
	]
	let argbuf = (textures.map({ $0.gpuResourceID._impl }) + [s2.gpuResourceID._impl]).withUnsafeBytes { ptr in
		let buf = gpu.makeBuffer(length: ptr.count)!
		buf.contents().copyMemory(from: ptr.baseAddress!, byteCount: ptr.count)
		return buf
	}
	for (i, tex) in textures.enumerated() {
		let tag = UInt32(i) << 8
		(0..<256).map({ (0xf0 & ($0 ^ ($0 << 4))) | tag }).withUnsafeBytes {
			tex.replace(region: MTLRegionMake2D(0, 0, 16, 16), mipmapLevel: 0, withBytes: $0.baseAddress!, bytesPerRow: 64)
		}
	}

	do {
		let cb = queue.makeCommandBuffer()!
		let enc = cb.makeComputeCommandEncoder()!
		withUnsafeBytes(of: argbuf.gpuAddress) { enc.setBytes($0.baseAddress!, length: $0.count, index: 0) }
		([0 as UInt32, 2, 0, 0] + sampdesc).withUnsafeBytes { enc.setBytes($0.baseAddress!, length: $0.count, index: 1) }
		enc.setTexture(textures[4], index: 0)
		enc.setTexture(textures[5], index: 1)
		enc.setSamplerState(s0, index: 0)
		enc.setSamplerState(s1, index: 1)
		enc.setComputePipelineState(pipe)
		enc.dispatchThreadgroups(MTLSizeMake(2, 2, 1), threadsPerThreadgroup: MTLSizeMake(8, 8, 1))
		enc.endEncoding()
		cb.commit()
		cb.waitUntilCompleted()
		if cb.status != .completed {
			print("Command buffer failed: \(cb.error?.localizedDescription ?? "Status was \(cb.status)")")
			exit(1)
		}
	}

	for (i, tex) in textures.enumerated() {
		var data = [UInt32](repeating: 0, count: 256)
		data.withUnsafeMutableBufferPointer {
			tex.getBytes($0.baseAddress!, bytesPerRow: 64, from: MTLRegionMake2D(0, 0, 16, 16), mipmapLevel: 0)
		}
		print("Texture \(i):")
		for pos in stride(from: 0, to: 256, by: 16) {
			print("\t" + data[pos..<pos + 16].map({ String(format: "%03x", $0) }).joined(separator: " "))
		}
	}
} else {
	print("No Apple GPU found")
}
```
Shader generated for test harness shader:
```
compute shader prolog:
   0: 0501040d00c43200     device_load      0, i32, xy, r0_r1, u2_u3, 0, signed, lsl 1
   8: 0519080d00c01200     device_load      0, i32, x, r3, u4_u5, 0, signed
  10: 0511180d00c01200     device_load      0, i32, x, r2, u4_u5, 1, signed
  18: 3800                 wait             0
  1a: 0521600600c43200     device_load      0, i32, xy, r4_r5, r0_r1, r3, unsigned, lsl 1
  22: 0511404600c43200     device_load      1, i32, xy, r2_r3, r0_r1, r2, unsigned, lsl 1
  2a: 0501300500c83200     device_load      0, i32, xy, r0_r1, r0_r1, 3, signed, lsl 2
  32: 3800                 wait             0
  34: 621900000000         mov_imm          r6, 0, 0b0
  3a: 62020000             mov_imm          r0h, 0
  3e: c520c03d00803000     uniform_store    2, i16, xy, 0, r4l_r4h, 12
  46: c530e03d00803000     uniform_store    2, i16, xy, 0, r6l_r6h, 14
  4e: 3801                 wait             1
  50: c510003d01803000     uniform_store    2, i16, xy, 0, r2l_r2h, 16
  58: c530203d01803000     uniform_store    2, i16, xy, 0, r6l_r6h, 18
  60: c500403d01803000     uniform_store    2, i16, xy, 0, r0l_r0h, 20
  68: c530603d01803000     uniform_store    2, i16, xy, 0, r6l_r6h, 22
  70: 8800                 stop

compute shader:
   0: f2051004             get_sr           r1.cache, sr80 (thread_position_in_grid.x)
   4: f2091104             get_sr           r2.cache, sr81 (thread_position_in_grid.y)
   8: be810a242800         convert          u32_to_f, r0.cache, r1.cache, rte
   e: 1231c2a219c2a039     icmpsel          ult, r12, r1.discard, u13, r1.discard, u13
  16: be850a442800         convert          u32_to_f, r1.cache, r2.cache, rte
  1c: 1235c4a219c4a039     icmpsel          ult, r13, r2.discard, u13, r2.discard, u13
  24: 1a81c0020100         fmul32           r0, r0.discard, 0.25
  2a: 1a85c2020100         fmul32           r1, r1.discard, 0.25
  30: 7e0814098000         mov              r2l, u10l
  36: 7e3d8c098000         mov              r15, u6
  3c: 7e3990098000         mov              r14, u8
  42: 3121001801622f00     texture_sample   0, 0b1100, 0b0, none, xyzw, 0b00, r8_r9_r10_r11, None, ts1, ss0, tex_2d, r0_r1, lod_min, u12l
  4a: 3111001801622f01     texture_sample   0, 0b1100, 0b0, none, xyzw, 0b00, r4_r5_r6_r7, None, ts1, ss1, tex_2d, r0_r1, lod_min, u12l
  52: 3101401801622fc4     texture_sample   0, 0b1100, 0b1, none, xyzw, 0b00, r0_r1_r2_r3, None, ts1, r2l, tex_2d, r0_r1.discard, lod_min, u12l
  5a: 3800                 wait             0
  5c: f1a19880de4a2000     image_write      r8_r9_r10_r11, r12_r13, 0, u0_u1, r15, tex_2d, rtz, 1, 0, 9, 0
  64: f1919880dc4a2000     image_write      r4_r5_r6_r7, r12_r13, 0, u0_u1, r14, tex_2d, rtz, 1, 0, 9, 0
  6c: 3801                 wait             1
  6e: f1819880024a2000     image_write      r0_r1_r2_r3, r12_r13, 0, None, ts2, tex_2d, rtz, 1, 0, 9, 0
  76: 8800                 stop
```
</details>
<details>
<summary>Test Sampler Replacement</summary>

Load ss1 with our custom sampler, which has linear filtering, pixel coordinates enabled, and the s wrap set to clamp to border color, replacing the existing one.  Also redirects the second output to tex1 instead of tex2 because it was easier.
```
Preshader:
   0: 0501040d00c43200     device_load      0, i32, xy, r0_r1, u2_u3, 0, signed, lsl 1
   8: 3800                 wait             0
   a: 0521600700c41200     device_load      0, i32, x, r4, r0_r1, 6, unsigned, lsl 1
  12: 0501000700c4f200     device_load      0, i32, xyzw, r0_r1_r2_r3, r0_r1, 0, unsigned, lsl 1
  1a: 3800                 wait             0
  1c: 620510000000         mov_imm          r1, 16, 0b0
  22: ad01100800000010     sampler_state_store ss1, u4_u5, r1
  2a: c500c03d00803000     uniform_store    2, i16, xy, 0, r0l_r0h, 12
  32: c510003d01803000     uniform_store    2, i16, xy, 0, r2l_r2h, 16
  3a: c520403d01803000     uniform_store    2, i16, xy, 0, r4l_r4h, 20
  42: 8800                 stop
```
```sh
cat > pre.S <<EOF
device_load 0, i32, xy, r0_r1, u2_u3, 0, signed, lsl 1
wait        0
device_load 0, i32, x, r4, r0_r1, 6, unsigned, lsl 1
device_load 0, i32, xyzw, r0_r1_r2_r3, r0_r1, 0, unsigned, lsl 1
wait        0
mov_imm     r1, 16, 0
sampler_state_store ss1, u4_u5, r1
uniform_store 2, i16, xy, 0, r0l_r0h, 12
uniform_store 2, i16, xy, 0, r2l_r2h, 16
uniform_store 2, i16, xy, 0, r4l_r4h, 20
stop
EOF
python3 metallib_replacer.py -i /tmp/SSStoreTest.metallib -c pre.S -o /tmp/SSStoreTest.metallib -n _agc.main.constant_program
```
```
Texture 0:
	500 540 580 5c0 5f0 5f0 5f0 5f0 5f0 5f0 5f0 5f0 5f0 5f0 5f0 5f0
	540 500 5c0 580 5b0 5b0 5b0 5b0 5b0 5b0 5b0 5b0 5b0 5b0 5b0 5b0
	580 5c0 500 540 570 570 570 570 570 570 570 570 570 570 570 570
	5c0 580 540 500 530 530 530 530 530 530 530 530 530 530 530 530
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
	5f0 5b0 570 530 500 500 500 500 500 500 500 500 500 500 500 500
Texture 1:
	300 400 500 504 508 50c 510 514 518 51c 520 524 528 52c 530 534
	300 400 500 504 508 50c 510 514 518 51c 520 524 528 52c 530 534
	300 400 500 504 508 50c 510 514 518 51c 520 524 528 52c 530 534
	302 403 504 506 508 50a 50c 512 518 51e 524 526 528 52a 52c 532
	304 406 508 508 508 508 508 510 518 520 528 528 528 528 528 530
	306 409 50c 50a 508 506 504 50e 518 522 52c 52a 528 526 524 52e
	308 40c 510 50c 508 504 500 50c 518 524 530 52c 528 524 520 52c
	30a 40f 514 512 510 50e 50c 512 518 51e 524 522 520 51e 51c 52a
	30c 412 518 518 518 518 518 518 518 518 518 518 518 518 518 528
	30e 415 51c 51e 520 522 524 51e 518 512 50c 50e 510 512 514 526
	310 418 520 524 528 52c 530 524 518 50c 500 504 508 50c 510 524
	312 41b 524 526 528 52a 52c 522 518 50e 504 506 508 50a 50c 522
	314 41e 528 528 528 528 528 520 518 510 508 508 508 508 508 520
	316 421 52c 52a 528 526 524 51e 518 512 50c 50a 508 506 504 51e
	318 424 530 52c 528 524 520 51c 518 514 510 50c 508 504 500 51c
	31a 427 534 532 530 52e 52c 52a 528 526 524 522 520 51e 51c 52a
Texture 2:
	200 210 220 230 240 250 260 270 280 290 2a0 2b0 2c0 2d0 2e0 2f0
	210 200 230 220 250 240 270 260 290 280 2b0 2a0 2d0 2c0 2f0 2e0
	220 230 200 210 260 270 240 250 2a0 2b0 280 290 2e0 2f0 2c0 2d0
	230 220 210 200 270 260 250 240 2b0 2a0 290 280 2f0 2e0 2d0 2c0
	240 250 260 270 200 210 220 230 2c0 2d0 2e0 2f0 280 290 2a0 2b0
	250 240 270 260 210 200 230 220 2d0 2c0 2f0 2e0 290 280 2b0 2a0
	260 270 240 250 220 230 200 210 2e0 2f0 2c0 2d0 2a0 2b0 280 290
	270 260 250 240 230 220 210 200 2f0 2e0 2d0 2c0 2b0 2a0 290 280
	280 290 2a0 2b0 2c0 2d0 2e0 2f0 200 210 220 230 240 250 260 270
	290 280 2b0 2a0 2d0 2c0 2f0 2e0 210 200 230 220 250 240 270 260
	2a0 2b0 280 290 2e0 2f0 2c0 2d0 220 230 200 210 260 270 240 250
	2b0 2a0 290 280 2f0 2e0 2d0 2c0 230 220 210 200 270 260 250 240
	2c0 2d0 2e0 2f0 280 290 2a0 2b0 240 250 260 270 200 210 220 230
	2d0 2c0 2f0 2e0 290 280 2b0 2a0 250 240 270 260 210 200 230 220
	2e0 2f0 2c0 2d0 2a0 2b0 280 290 260 270 240 250 220 230 200 210
	2f0 2e0 2d0 2c0 2b0 2a0 290 280 270 260 250 240 230 220 210 200
Texture 3:
	300 310 320 330 340 350 360 370 380 390 3a0 3b0 3c0 3d0 3e0 3f0
	310 300 330 320 350 340 370 360 390 380 3b0 3a0 3d0 3c0 3f0 3e0
	320 330 300 310 360 370 340 350 3a0 3b0 380 390 3e0 3f0 3c0 3d0
	330 320 310 300 370 360 350 340 3b0 3a0 390 380 3f0 3e0 3d0 3c0
	340 350 360 370 300 310 320 330 3c0 3d0 3e0 3f0 380 390 3a0 3b0
	350 340 370 360 310 300 330 320 3d0 3c0 3f0 3e0 390 380 3b0 3a0
	360 370 340 350 320 330 300 310 3e0 3f0 3c0 3d0 3a0 3b0 380 390
	370 360 350 340 330 320 310 300 3f0 3e0 3d0 3c0 3b0 3a0 390 380
	380 390 3a0 3b0 3c0 3d0 3e0 3f0 300 310 320 330 340 350 360 370
	390 380 3b0 3a0 3d0 3c0 3f0 3e0 310 300 330 320 350 340 370 360
	3a0 3b0 380 390 3e0 3f0 3c0 3d0 320 330 300 310 360 370 340 350
	3b0 3a0 390 380 3f0 3e0 3d0 3c0 330 320 310 300 370 360 350 340
	3c0 3d0 3e0 3f0 380 390 3a0 3b0 340 350 360 370 300 310 320 330
	3d0 3c0 3f0 3e0 390 380 3b0 3a0 350 340 370 360 310 300 330 320
	3e0 3f0 3c0 3d0 3a0 3b0 380 390 360 370 340 350 320 330 300 310
	3f0 3e0 3d0 3c0 3b0 3a0 390 380 370 360 350 340 330 320 310 300
Texture 4:
	500 500 500 504 508 50c 510 514 518 51c 520 524 528 52c 530 534
	500 500 500 504 508 50c 510 514 518 51c 520 524 528 52c 530 534
	500 500 500 504 508 50c 510 514 518 51c 520 524 528 52c 530 534
	504 504 504 506 508 50a 50c 512 518 51e 524 526 528 52a 52c 532
	508 508 508 508 508 508 508 510 518 520 528 528 528 528 528 530
	50c 50c 50c 50a 508 506 504 50e 518 522 52c 52a 528 526 524 52e
	510 510 510 50c 508 504 500 50c 518 524 530 52c 528 524 520 52c
	514 514 514 512 510 50e 50c 512 518 51e 524 522 520 51e 51c 52a
	518 518 518 518 518 518 518 518 518 518 518 518 518 518 518 528
	51c 51c 51c 51e 520 522 524 51e 518 512 50c 50e 510 512 514 526
	520 520 520 524 528 52c 530 524 518 50c 500 504 508 50c 510 524
	524 524 524 526 528 52a 52c 522 518 50e 504 506 508 50a 50c 522
	528 528 528 528 528 528 528 520 518 510 508 508 508 508 508 520
	52c 52c 52c 52a 528 526 524 51e 518 512 50c 50a 508 506 504 51e
	530 530 530 52c 528 524 520 51c 518 514 510 50c 508 504 500 51c
	534 534 534 532 530 52e 52c 52a 528 526 524 522 520 51e 51c 52a
Texture 5:
	500 510 520 530 540 550 560 570 580 590 5a0 5b0 5c0 5d0 5e0 5f0
	510 500 530 520 550 540 570 560 590 580 5b0 5a0 5d0 5c0 5f0 5e0
	520 530 500 510 560 570 540 550 5a0 5b0 580 590 5e0 5f0 5c0 5d0
	530 520 510 500 570 560 550 540 5b0 5a0 590 580 5f0 5e0 5d0 5c0
	540 550 560 570 500 510 520 530 5c0 5d0 5e0 5f0 580 590 5a0 5b0
	550 540 570 560 510 500 530 520 5d0 5c0 5f0 5e0 590 580 5b0 5a0
	560 570 540 550 520 530 500 510 5e0 5f0 5c0 5d0 5a0 5b0 580 590
	570 560 550 540 530 520 510 500 5f0 5e0 5d0 5c0 5b0 5a0 590 580
	580 590 5a0 5b0 5c0 5d0 5e0 5f0 500 510 520 530 540 550 560 570
	590 580 5b0 5a0 5d0 5c0 5f0 5e0 510 500 530 520 550 540 570 560
	5a0 5b0 580 590 5e0 5f0 5c0 5d0 520 530 500 510 560 570 540 550
	5b0 5a0 590 580 5f0 5e0 5d0 5c0 530 520 510 500 570 560 550 540
	5c0 5d0 5e0 5f0 580 590 5a0 5b0 540 550 560 570 500 510 520 530
	5d0 5c0 5f0 5e0 590 580 5b0 5a0 550 540 570 560 510 500 530 520
	5e0 5f0 5c0 5d0 5a0 5b0 580 590 560 570 540 550 520 530 500 510
	5f0 5e0 5d0 5c0 5b0 5a0 590 580 570 560 550 540 530 520 510 500
```
</details>